### PR TITLE
Unit test support via elm-test

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ development environment. This means that it tries as much as possible to bundle 
 - [x] Watch and recompile via [modd](https://github.com/cortesi/modd)
 - [x] Live reload via [devd](https://github.com/cortesi/devd)
 - [x] File generators based on templates
+- [x] Support for unit testing (optional)
 
 ## Setup from scratch
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ Some guidelines:
 
 It may also be worth checking out the documentation for the software used in this boilerplate (like Devd or Modd), as they provide functionality that it's not covered here.
 
+## Testing
+
+It's possible to add support for unit testing via <https://github.com/rtfeldman/node-elm-test>.
+
+To do that, it's enough to call `make test`, which will install the needed dependencies. Note that this requires Node to be installed.
+
+Calling `make test` again will rerun the test suite.
+
 ## FAQs/Comments
 
 - I don't think this should use X, Y is a better fit.

--- a/elm.mk
+++ b/elm.mk
@@ -3,12 +3,14 @@ ELM_ENTRY = src/Main.elm
 DEVD_VERSION = 0.3
 WELLINGTON_VERSION = 1.0.2
 MODD_VERSION = 0.2
+ELM_TEST_VERSION = 0.16
 OS := $(shell uname)
 INSTALL_TARGETS = src bin build \
 									elm-package.json \
 									src/Main.elm src/interop.js styles/main.scss index.html \
 									bin/modd modd.conf \
 									bin/devd bin/wt \
+									node_modules/.bin/elm-test \
 									.gitignore
 COMPILE_TARGETS = build/main.js build/main.css build/index.html build/interop.js
 
@@ -74,6 +76,9 @@ modd.conf:
 
 elm-package.json:
 	echo "$$elm_package_json" > $@
+
+node_modules/.bin/elm-test:
+	npm install elm-test@${ELM_TEST_VERSION}
 
 .gitignore:
 	echo "$$gitignore" > $@

--- a/elm.mk
+++ b/elm.mk
@@ -1,5 +1,6 @@
-.PHONY: install server watch clean help
+.PHONY: install server watch clean test help
 ELM_ENTRY = src/Main.elm
+NODE_BIN_DIRECTORY = node_modules/.bin
 DEVD_VERSION = 0.3
 WELLINGTON_VERSION = 1.0.2
 MODD_VERSION = 0.2
@@ -10,9 +11,9 @@ INSTALL_TARGETS = src bin build \
 									src/Main.elm src/interop.js styles/main.scss index.html \
 									bin/modd modd.conf \
 									bin/devd bin/wt \
-									node_modules/.bin/elm-test \
 									.gitignore
 COMPILE_TARGETS = build/main.js build/main.css build/index.html build/interop.js
+TEST_TARGETS = $(NODE_BIN_DIRECTORY)/elm-test test/TestRunner.elm
 
 ifeq ($(OS),Darwin)
 	DEVD_URL = "https://github.com/cortesi/devd/releases/download/v${DEVD_VERSION}/devd-${DEVD_VERSION}-osx64.tgz"
@@ -37,6 +38,9 @@ watch: ## Watches files for changes, runs a local dev server and triggers live r
 clean: ## Removes compiled files
 	rm build/*
 
+test: $(TEST_TARGETS) ## Runs unit tests via elm-test
+	$(NODE_BIN_DIRECTORY)/elm-test test/TestRunner.elm
+
 help: ## Prints a help guide
 	@echo "Available tasks:"
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -52,6 +56,11 @@ src/Main.elm: src
 
 src/interop.js: src
 	test -s $@ || echo "$$interop_js" > $@
+
+test/TestRunner.elm:
+	$(NODE_BIN_DIRECTORY)/elm-test init --yes
+	mkdir -p test
+	mv *.elm test/
 
 index.html:
 	test -s $@ || echo "$$index_html" > $@
@@ -168,7 +177,8 @@ define elm_package_json
     "repository": "https://github.com/user/project.git",
     "license": "BSD3",
     "source-directories": [
-        "src"
+        "src",
+        "test"
     ],
     "exposed-modules": [],
     "dependencies": {


### PR DESCRIPTION
This PR adds a new target `test` which runs unit tests via https://github.com/rtfeldman/node-elm-test.

The test toolchain relies on a local copy of the package, but it requires Node to be installed.

Note that testing support is not installed by default, instead it gets lazily activated the first time `make test` is invoked.
