### PR TITLE
Generates Makefile that includes elm.mk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 .PHONY: test
 
 test: dummy
-	cp elm.mk dummy/Makefile
-	cd dummy && $(MAKE) install && $(MAKE)
+	cp elm.mk dummy/elm.mk
+	cd dummy && $(MAKE) -f elm.mk install && $(MAKE)
 	./tests.sh
 	rm -r dummy
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,11 @@ development environment. This means that it tries as much as possible to bundle 
 ## Setup from scratch
 
 - `mkdir my_new_project && cd my_new_project`
-- `curl -o Makefile https://raw.githubusercontent.com/cloud8421/elm.mk/master/elm.mk`
-- `make install`
+- `curl https://raw.githubusercontent.com/cloud8421/elm.mk/master/elm.mk`
+- `make -f elm.mk install`
+
+This will generate the needed folder structure and files. Note that at the end of `make install`, you're left with
+an empty `Makefile` that includes `elm.mk`, so that you can extend it for your needs and/or override its behaviour.
 
 ## Project workflow
 

--- a/elm.mk
+++ b/elm.mk
@@ -7,6 +7,7 @@ MODD_VERSION = 0.2
 ELM_TEST_VERSION = 0.16
 OS := $(shell uname)
 INSTALL_TARGETS = src bin build \
+									Makefile \
 									elm-package.json \
 									src/Main.elm src/interop.js styles/main.scss index.html \
 									bin/modd modd.conf \
@@ -47,6 +48,9 @@ help: ## Prints a help guide
 
 build bin src styles:
 	mkdir -p $@
+
+Makefile:
+	test -s $@ || echo "$$Makefile" > $@
 
 styles/main.scss: styles
 	test -s $@ || touch $@
@@ -103,6 +107,11 @@ build/interop.js: src/interop.js
 
 build/index.html: index.html
 	cp $? $@
+
+define Makefile
+include elm.mk
+endef
+export Makefile
 
 define modd_config
 src/**/*.elm {


### PR DESCRIPTION
Instead of suggesting to download `elm.mk` and call it `Makefile`, it's better to include `elm.mk` in a new or existing `Makefile`. This way customisation becomes much easier.
