### PR TITLE
Adds support for custom targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,34 @@ Some guidelines:
 
 It may also be worth checking out the documentation for the software used in this boilerplate (like Devd or Modd), as they provide functionality that it's not covered here.
 
+## Extending install targets
+
+Install targets represent tooling dependencies that your project has.
+
+For example you may wanna add support for image compression using a hypothetical tool called `compress`, whose binary you can download.
+
+In your `Makefile`, you can add a `CUSTOM_INSTALL_TARGETS` definition, which will be picked up by `make install`:
+
+```
+CUSTOM_INSTALL_TARGETS := bin/compress
+
+bin/compress:
+  curl -o $@ http://example.com/compress
+```
+
+## Extending compile targets
+
+Compile targets represent the artifacts your project builds every time you run `make`.
+
+For example, if you want to add a second html page to the project, you can extend `CUSTOM_COMPILE_TARGETS`:
+
+```
+CUSTOM_COMPILE_TARGETS := build/home.html
+
+build/home.html: home.html
+  cp $< $@
+```
+
 ## Testing
 
 It's possible to add support for unit testing via <https://github.com/rtfeldman/node-elm-test>.

--- a/elm.mk
+++ b/elm.mk
@@ -13,8 +13,13 @@ INSTALL_TARGETS = src bin build \
 									src/Main.elm src/interop.js styles/main.scss index.html \
 									bin/modd modd.conf \
 									bin/devd bin/wt \
-									.gitignore
-COMPILE_TARGETS = build/main.js build/main.css build/index.html build/interop.js
+									.gitignore \
+									$(CUSTOM_INSTALL_TARGETS)
+COMPILE_TARGETS = build/main.js \
+									build/main.css \
+									build/index.html \
+									build/interop.js \
+									$(CUSTOM_COMPILE_TARGETS)
 TEST_TARGETS = $(NODE_BIN_DIRECTORY)/elm-test test/TestRunner.elm
 
 ifeq ($(OS),Darwin)


### PR DESCRIPTION
This introduces CUSTOM_INSTALL_TARGETS and CUSTOM_COMPILE_TARGETS, used to
provide extension hooks for `make install` and `make`.
