### PR TITLE
Support for production target with minified files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 test: dummy
 	cp elm.mk dummy/elm.mk
-	cd dummy && $(MAKE) -f elm.mk install && $(MAKE)
+	cd dummy && $(MAKE) -f elm.mk install && $(MAKE) && $(MAKE) prod
 	./tests.sh
 	rm -r dummy
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Main commands:
 
 - `make install`: installs all needed dependencies
 - `make`: compiles the project into `build`
+- `make prod`: compresses compiled files in `dist` (only supports main js file for now)
 - `make server`: serves the build folder with a local http server
 - `make watch`: starts the file watcher and the http server, recompiling files on save
 - `make clean`: deletes all compiled files

--- a/elm.mk
+++ b/elm.mk
@@ -16,6 +16,7 @@ INSTALL_TARGETS = src bin $(BUILD_FOLDER) \
 									src/Main.elm src/interop.js styles/main.scss index.html \
 									bin/modd modd.conf \
 									bin/devd bin/wt \
+									bin/mo \
 									.gitignore \
 									$(CUSTOM_INSTALL_TARGETS)
 COMPILE_TARGETS = $(BUILD_FOLDER) \
@@ -27,10 +28,12 @@ COMPILE_TARGETS = $(BUILD_FOLDER) \
 DIST_TARGETS = $(DIST_FOLDER) \
 							 $(DIST_FOLDER)/main.min.js \
 							 $(DIST_FOLDER)/interop.min.js \
-							 $(DIST_FOLDER)/main.min.css
+							 $(DIST_FOLDER)/main.min.css \
+							 $(DIST_FOLDER)/index.html
 TEST_TARGETS = $(NODE_BIN_DIRECTORY)/elm-test tests/Main.elm
 SERVER_OPTS = -w $(BUILD_FOLDER) -l $(BUILD_FOLDER)/ $(CUSTOM_SERVER_OPTS)
 
+MO_URL = "https://raw.githubusercontent.com/tests-always-included/mo/master/mo"
 ifeq ($(OS),Darwin)
 	DEVD_URL = "https://github.com/cortesi/devd/releases/download/v${DEVD_VERSION}/devd-${DEVD_VERSION}-osx64.tgz"
 	WELLINGTON_URL = "https://github.com/wellington/wellington/releases/download/v${WELLINGTON_VERSION}/wt_v${WELLINGTON_VERSION}_darwin_amd64.tar.gz"
@@ -99,6 +102,10 @@ bin/modd:
 	tar -xzf $@.tgz -C bin/ --strip 1
 	rm $@.tgz
 
+bin/mo:
+	curl $(MO_URL) -L -o $@
+	chmod +x $@
+
 modd.conf:
 	echo "$$modd_config" > $@
 
@@ -124,7 +131,7 @@ $(BUILD_FOLDER)/interop.js: src/interop.js
 	cp $? $@
 
 $(BUILD_FOLDER)/index.html: index.html
-	cp $? $@
+	main_css=/main.css main_js=/main.js interop_js=/interop.js bin/mo index.html > $@
 
 $(DIST_FOLDER)/main.min.css: styles/*.scss
 	bin/wt compile -s compressed -b $(DIST_FOLDER)/ styles/main.scss
@@ -135,6 +142,9 @@ $(DIST_FOLDER)/main.min.js: $(BUILD_FOLDER)/main.js $(NODE_BIN_DIRECTORY)/uglify
 
 $(DIST_FOLDER)/interop.min.js: $(BUILD_FOLDER)/interop.js $(NODE_BIN_DIRECTORY)/uglifyjs
 	$(NODE_BIN_DIRECTORY)/uglifyjs --compress --mangle --output $@ -- $(BUILD_FOLDER)/interop.js
+
+$(DIST_FOLDER)/index.html: index.html
+	main_css=/main.min.css main_js=/main.min.js interop_js=/interop.min.js bin/mo index.html > $@
 
 define Makefile
 
@@ -245,12 +255,12 @@ define index_html
 <head>
   <meta charset="UTF-8">
   <title>Elm Project</title>
-  <link rel="stylesheet" href="/main.css">
+  <link rel="stylesheet" href="{{main_css}}">
 </head>
 <body>
 </body>
-  <script type="text/javascript" src="main.js"></script>
-  <script type="text/javascript" src="interop.js"></script>
+  <script type="text/javascript" src="{{main_js}}"></script>
+  <script type="text/javascript" src="{{interop_js}}"></script>
 </html>
 endef
 export index_html

--- a/elm.mk
+++ b/elm.mk
@@ -26,7 +26,8 @@ COMPILE_TARGETS = $(BUILD_FOLDER) \
 									$(CUSTOM_COMPILE_TARGETS)
 DIST_TARGETS = $(DIST_FOLDER) \
 							 $(DIST_FOLDER)/main.min.js \
-							 $(DIST_FOLDER)/interop.min.js
+							 $(DIST_FOLDER)/interop.min.js \
+							 $(DIST_FOLDER)/main.min.css
 TEST_TARGETS = $(NODE_BIN_DIRECTORY)/elm-test tests/Main.elm
 SERVER_OPTS = -w $(BUILD_FOLDER) -l $(BUILD_FOLDER)/ $(CUSTOM_SERVER_OPTS)
 
@@ -124,6 +125,10 @@ $(BUILD_FOLDER)/interop.js: src/interop.js
 
 $(BUILD_FOLDER)/index.html: index.html
 	cp $? $@
+
+$(DIST_FOLDER)/main.min.css: styles/*.scss
+	bin/wt compile -s compressed -b $(DIST_FOLDER)/ styles/main.scss
+	mv $(DIST_FOLDER)/main.css $@
 
 $(DIST_FOLDER)/main.min.js: $(BUILD_FOLDER)/main.js $(NODE_BIN_DIRECTORY)/uglifyjs
 	$(NODE_BIN_DIRECTORY)/uglifyjs --compress --mangle --output $@ -- $(BUILD_FOLDER)/main.js

--- a/elm.mk
+++ b/elm.mk
@@ -25,7 +25,8 @@ COMPILE_TARGETS = $(BUILD_FOLDER) \
 									$(BUILD_FOLDER)/interop.js \
 									$(CUSTOM_COMPILE_TARGETS)
 DIST_TARGETS = $(DIST_FOLDER) \
-							 $(DIST_FOLDER)/main.min.js
+							 $(DIST_FOLDER)/main.min.js \
+							 $(DIST_FOLDER)/interop.min.js
 TEST_TARGETS = $(NODE_BIN_DIRECTORY)/elm-test tests/Main.elm
 SERVER_OPTS = -w $(BUILD_FOLDER) -l $(BUILD_FOLDER)/ $(CUSTOM_SERVER_OPTS)
 
@@ -120,6 +121,9 @@ $(BUILD_FOLDER)/main.js: $(ELM_FILES)
 
 $(DIST_FOLDER)/main.min.js: $(BUILD_FOLDER)/main.js $(NODE_BIN_DIRECTORY)/uglifyjs
 	$(NODE_BIN_DIRECTORY)/uglifyjs --compress --mangle --output $@ -- $(BUILD_FOLDER)/main.js
+
+$(DIST_FOLDER)/interop.min.js: $(BUILD_FOLDER)/interop.js $(NODE_BIN_DIRECTORY)/uglifyjs
+	$(NODE_BIN_DIRECTORY)/uglifyjs --compress --mangle --output $@ -- $(BUILD_FOLDER)/interop.js
 
 $(BUILD_FOLDER)/interop.js: src/interop.js
 	cp $? $@

--- a/elm.mk
+++ b/elm.mk
@@ -119,17 +119,17 @@ $(BUILD_FOLDER)/main.css: styles/*.scss
 $(BUILD_FOLDER)/main.js: $(ELM_FILES)
 	elm make $(ELM_ENTRY) --yes --warn --output $@
 
-$(DIST_FOLDER)/main.min.js: $(BUILD_FOLDER)/main.js $(NODE_BIN_DIRECTORY)/uglifyjs
-	$(NODE_BIN_DIRECTORY)/uglifyjs --compress --mangle --output $@ -- $(BUILD_FOLDER)/main.js
-
-$(DIST_FOLDER)/interop.min.js: $(BUILD_FOLDER)/interop.js $(NODE_BIN_DIRECTORY)/uglifyjs
-	$(NODE_BIN_DIRECTORY)/uglifyjs --compress --mangle --output $@ -- $(BUILD_FOLDER)/interop.js
-
 $(BUILD_FOLDER)/interop.js: src/interop.js
 	cp $? $@
 
 $(BUILD_FOLDER)/index.html: index.html
 	cp $? $@
+
+$(DIST_FOLDER)/main.min.js: $(BUILD_FOLDER)/main.js $(NODE_BIN_DIRECTORY)/uglifyjs
+	$(NODE_BIN_DIRECTORY)/uglifyjs --compress --mangle --output $@ -- $(BUILD_FOLDER)/main.js
+
+$(DIST_FOLDER)/interop.min.js: $(BUILD_FOLDER)/interop.js $(NODE_BIN_DIRECTORY)/uglifyjs
+	$(NODE_BIN_DIRECTORY)/uglifyjs --compress --mangle --output $@ -- $(BUILD_FOLDER)/interop.js
 
 define Makefile
 

--- a/tests.sh
+++ b/tests.sh
@@ -18,7 +18,7 @@ function fileExists() {
 files="bin/modd elm-package.json modd.conf \
        index.html styles/main.scss src/interop.js src/Main.elm \
        build/index.html build/interop.js build/main.js build/main.css \
-       dist/main.min.js dist/interop.min.js"
+       dist/main.min.js dist/interop.min.js dist/main.min.css"
 
 for file in $files
 do

--- a/tests.sh
+++ b/tests.sh
@@ -18,7 +18,7 @@ function fileExists() {
 files="bin/modd elm-package.json modd.conf \
        index.html styles/main.scss src/interop.js src/Main.elm \
        build/index.html build/interop.js build/main.js build/main.css \
-       dist/main.min.js"
+       dist/main.min.js dist/interop.min.js"
 
 for file in $files
 do

--- a/tests.sh
+++ b/tests.sh
@@ -17,7 +17,8 @@ function fileExists() {
 
 files="bin/modd elm-package.json modd.conf \
        index.html styles/main.scss src/interop.js src/Main.elm \
-       build/index.html build/interop.js build/main.js build/main.css"
+       build/index.html build/interop.js build/main.js build/main.css \
+       dist/main.min.js"
 
 for file in $files
 do

--- a/tests.sh
+++ b/tests.sh
@@ -18,7 +18,7 @@ function fileExists() {
 files="bin/modd elm-package.json modd.conf \
        index.html styles/main.scss src/interop.js src/Main.elm \
        build/index.html build/interop.js build/main.js build/main.css \
-       dist/main.min.js dist/interop.min.js dist/main.min.css"
+       dist/main.min.js dist/interop.min.js dist/main.min.css dist/index.html"
 
 for file in $files
 do


### PR DESCRIPTION
Add support for minified build artifacts under `dist`.

Supports:

- [x] `main.js`
- [x] `interop.js`
- [x] `main.css`

NOTE: `index.html` has correct references to minified files, but it's not minified.

Closes #17 