### PR TITLE
Issue 26 tests do not pass

### DIFF
--- a/elm.mk
+++ b/elm.mk
@@ -10,18 +10,17 @@ UGLIFY_JS_VERSION = 2.7.4
 OS := $(shell uname)
 BUILD_FOLDER = build
 DIST_FOLDER = dist
-INSTALL_TARGETS = src bin $(BUILD_FOLDER) \
-									$(BUILD_FOLDER)/images \
-									Makefile \
-									elm-package.json \
-									src/Main.elm src/State.elm src/Types.elm src/View.elm \
-									src/boot.js styles/main.scss index.html \
-									images \
-									bin/modd modd.conf \
-									bin/devd bin/wt \
-									bin/mo \
-									.gitignore \
-									$(CUSTOM_INSTALL_TARGETS)
+INSTALL_TARGETS = src bin \
+							Makefile \
+							elm-package.json \
+							src/Main.elm src/State.elm src/Types.elm src/View.elm \
+							src/boot.js styles/main.scss index.html \
+							images \
+							bin/modd modd.conf \
+							bin/devd bin/wt \
+							bin/mo \
+							.gitignore \
+							$(CUSTOM_INSTALL_TARGETS)
 COMPILE_TARGETS = $(BUILD_FOLDER) \
 									$(BUILD_FOLDER)/main.js \
 									$(BUILD_FOLDER)/main.css \


### PR DESCRIPTION
Creating build/images in the install step was resulting in build/images/images after call to make, solution is to remove these folders from the INSTALL_TARGETS list.

As described in Issue #26