### PR TITLE
Elm 0.19 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ dummy:
 	rm -rf $@
 	mkdir $@
 	cp elm.mk dummy/
-	cd dummy && $(MAKE) --jobs=4 -f elm.mk && cd ..
+	cd dummy && $(MAKE) all prod --jobs=4 -f elm.mk && cd ..
 .PHONY: dummy
 
 test: dummy
@@ -11,6 +11,6 @@ test: dummy
 
 test-incremental:
 	cp elm.mk dummy/
-	cd dummy && $(MAKE) --jobs=4 -f elm.mk && cd ..
+	cd dummy && $(MAKE) all prod --jobs=4 -f elm.mk && cd ..
 	ruby test.rb
 .PHONY: test-incremental

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ an empty `Makefile` that includes `elm.mk`, so that you can extend it for your n
 Main commands:
 
 - `make`: compiles the project into `build` (installing dependencies if needed)
-- `make dist`: compresses compiled files in `dist`
+- `make dist`: compiles the project into `dist` with production optimisations
 - `make serve`: serves the build folder with a local http server
 - `make watch`: starts the file watcher and the http server, recompiling files on save
 - `make help`: shows all main tasks

--- a/elm.mk
+++ b/elm.mk
@@ -40,7 +40,7 @@ MODD := $(BIN)/modd
 WT := $(BIN)/wt
 
 DEVD_VERSION := 0.8
-ELM_VERSION := 0.18.0
+ELM_VERSION := 0.19.0
 MO_VERSION := 2.0.4
 MODD_VERSION := 0.5
 WT_VERSION := 1.0.4
@@ -49,12 +49,12 @@ MO_URL := "https://raw.githubusercontent.com/tests-always-included/mo/${MO_VERSI
 
 ifeq ($(OS),Darwin)
 	DEVD_URL := "https://github.com/cortesi/devd/releases/download/v${DEVD_VERSION}/devd-${DEVD_VERSION}-osx64.tgz"
-	ELM_URL := "https://dl.bintray.com/elmlang/elm-platform/${ELM_VERSION}/darwin-x64.tar.gz"
+	ELM_URL := "https://github.com/elm/compiler/releases/download/${ELM_VERSION}/binaries-for-mac.tar.gz"
 	MODD_URL := "https://github.com/cortesi/modd/releases/download/v${MODD_VERSION}/modd-${MODD_VERSION}-osx64.tgz"
 	WT_URL := "https://github.com/wellington/wellington/releases/download/v${WT_VERSION}/wt_v${WT_VERSION}_darwin_amd64.tar.gz"
 else
 	DEVD_URL := "https://github.com/cortesi/devd/releases/download/v${DEVD_VERSION}/devd-${DEVD_VERSION}-linux64.tgz"
-	ELM_URL := "https://dl.bintray.com/elmlang/elm-platform/${ELM_VERSION}/linux-x64.tar.gz"
+	ELM_URL := "https://github.com/elm/compiler/releases/download/${ELM_VERSION}/binaries-for-linux.tar.gz"
 	MODD_URL := "https://github.com/cortesi/modd/releases/download/v${MODD_VERSION}/modd-${MODD_VERSION}-linux64.tgz"
 	WT_URL := "https://github.com/wellington/wellington/releases/download/v${WT_VERSION}/wt_v${WT_VERSION}_linux_amd64.tar.gz"
 endif
@@ -65,7 +65,7 @@ DEVD_OPTIONS := -m $(BUILD) -f /index.html
 
 SUPPORT_TARGETS := Makefile \
 	.gitignore \
-	elm-package.json \
+	elm.json \
 	modd.conf
 
 TOOL_TARGETS := $(BIN) \
@@ -77,9 +77,6 @@ TOOL_TARGETS := $(BIN) \
 
 APPLICATION_TARGETS := index.html \
 	$(ELM_SRC) \
-	$(ELM_SRC)/Types.elm \
-	$(ELM_SRC)/State.elm \
-	$(ELM_SRC)/View.elm \
 	$(ELM_SRC)/Main.elm \
 	boot.js \
 	service-worker.js \
@@ -131,7 +128,7 @@ $(DEVD):
 
 $(ELM):
 	${curl} ${ELM_URL} -L -o $@.tgz
-	tar -xzf $@.tgz -C bin/ --strip 1
+	tar -xzf $@.tgz -C bin/
 	rm $@.tgz
 
 $(MO):
@@ -156,8 +153,8 @@ Makefile:
 .gitignore:
 	$(call lazy_tpl,"$$gitignore")
 
-elm-package.json:
-	$(call lazy_tpl,"$$elm_package_json")
+elm.json:
+	$(call lazy_tpl,"$$elm_json")
 
 modd.conf: $(MO)
 	echo "$$modd_config" | build=$(BUILD) elm_src=$(ELM_SRC) scss_src=$(SCSS_SRC) $(MO) > $@
@@ -169,15 +166,6 @@ $(ELM_SRC):
 
 index.html:
 	$(call lazy_tpl,"$$index_html")
-
-$(ELM_SRC)/Types.elm:
-	$(call lazy_tpl,"$$elm_types")
-
-$(ELM_SRC)/State.elm:
-	$(call lazy_tpl,"$$elm_state")
-
-$(ELM_SRC)/View.elm:
-	$(call lazy_tpl,"$$elm_view")
 
 $(ELM_SRC)/Main.elm:
 	$(call lazy_tpl,"$$elm_main")
@@ -203,7 +191,7 @@ $(BUILD)/index.html: index.html $(MO)
 	main_js=/main.js boot_js=/boot.js main_css=/main.css service_worker_js=/service-worker.js $(MO) index.html > $@
 
 $(BUILD)/main.js: $(ELM_SRC)/Main.elm $(ELM_SRC_FILES) $(ELM)
-	$(ELM)-make $(ELM_SRC)/Main.elm --yes --warn --output $@
+	$(ELM) make $(ELM_SRC)/Main.elm --debug --output $@
 
 $(BUILD)/boot.js: boot.js
 	cp $< $@
@@ -233,26 +221,33 @@ elm.js
 endef
 export gitignore
 
-define elm_package_json
+define elm_json
 {
-    "version": "1.0.0",
-    "summary": "helpful summary of your project, less than 80 characters",
-    "repository": "https://github.com/user/project.git",
-    "license": "BSD3",
+    "type": "application",
     "source-directories": [
-        "src",
-        "test"
+        "src"
     ],
-    "exposed-modules": [],
+    "elm-version": "0.19.0",
     "dependencies": {
-        "elm-lang/core": "5.0.0 <= v < 6.0.0",
-        "elm-lang/html": "2.0.0 <= v < 3.0.0",
-        "elm-lang/http": "1.0.0 <= v < 2.0.0"
+        "direct": {
+            "elm/browser": "1.0.0",
+            "elm/core": "1.0.0",
+            "elm/html": "1.0.0"
+        },
+        "indirect": {
+            "elm/json": "1.0.0",
+            "elm/time": "1.0.0",
+            "elm/url": "1.0.0",
+            "elm/virtual-dom": "1.0.0"
+        }
     },
-    "elm-version": "0.18.0 <= v < 0.19.0"
+    "test-dependencies": {
+        "direct": {},
+        "indirect": {}
+    }
 }
 endef
-export elm_package_json
+export elm_json
 
 define index_html
 <!DOCTYPE HTML>
@@ -276,8 +271,17 @@ define index_html
 endef
 export index_html
 
-define elm_types
-module Types exposing (..)
+define elm_main
+module Main exposing (main)
+
+import Browser exposing (Document)
+import Html exposing (h1, text)
+import Platform.Cmd as Cmd
+import Platform.Sub as Sub
+
+
+type alias Flags =
+    Int
 
 
 type Msg
@@ -285,70 +289,41 @@ type Msg
 
 
 type alias Model =
-    Int
-
-endef
-export elm_types
-
-define elm_state
-module State exposing (..)
-
-import Types exposing (..)
+    { count : Int }
 
 
-init : ( Model, Cmd Msg )
-init =
-    0 ! []
+main : Program Flags Model Msg
+main =
+    Browser.document
+        { init = init
+        , view = view
+        , update = update
+        , subscriptions = subscriptions
+        }
+
+
+init : Flags -> ( Model, Cmd Msg )
+init initialCount =
+    ( { count = initialCount }, Cmd.none )
+
+
+view : Model -> Document Msg
+view model =
+    { title = "My new app"
+    , body =
+        [ h1 [] [ text "it works" ]
+        ]
+    }
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
-    case msg of
-        NoOp ->
-            model ! []
-
-endef
-export elm_state
-
-define elm_view
-module View exposing (..)
-
-import Html exposing (Html, div, text)
-import Types exposing (..)
-
-
-root : Model -> Html Msg
-root model =
-    div []
-        [ model |> toString |> text ]
-
-endef
-export elm_view
-
-define elm_main
-module Main exposing (..)
-
-import Html
-import Platform.Sub as Sub
-import State
-import Types exposing (..)
-import View
+    ( model, Cmd.none )
 
 
 subscriptions : Model -> Sub Msg
 subscriptions model =
     Sub.none
-
-
-main : Program Never Model Msg
-main =
-    Html.program
-        { init = State.init
-        , view = View.root
-        , update = State.update
-        , subscriptions = subscriptions
-        }
-
 endef
 export elm_main
 

--- a/elm.mk
+++ b/elm.mk
@@ -218,6 +218,8 @@ define gitignore
 node_modules
 elm-stuff
 elm.js
+$(BUILD)
+$(BIN)
 endef
 export gitignore
 

--- a/elm.mk
+++ b/elm.mk
@@ -330,7 +330,10 @@ export elm_main
 define boot_js
 window.onload = function() {
   var container = document.getElementById("app");
-  Elm.Main.embed(container);
+  Elm.Main.init({
+    node: container,
+    flags: 10
+  });
 };
 endef
 export boot_js

--- a/test.rb
+++ b/test.rb
@@ -47,6 +47,7 @@ describe "Elm.mk test" do
       contents.must_include "node_modules"
       contents.must_include "elm.js"
       contents.must_include "build"
+      contents.must_include "dist"
       contents.must_include "bin"
     end
 
@@ -129,6 +130,45 @@ describe "Elm.mk test" do
       contents.wont_be_empty
       contents.must_have_at_least_one_matching(/body/)
     end
+  end
+end
+
+describe "dist targets" do
+  it "dist/index.html" do
+    contents = File.readlines_stripped("dummy/dist/index.html")
+
+    contents.wont_be_empty
+    contents.must_have_at_least_one_matching(/\/main\.js/)
+    contents.must_have_at_least_one_matching(/\/boot\.js/)
+    contents.must_have_at_least_one_matching(/\/service-worker\.js/)
+    contents.must_have_at_least_one_matching(/\/main\.css/)
+  end
+
+  it "dist/main.js" do
+    contents = File.readlines_stripped("dummy/dist/main.js")
+
+    contents.wont_be_empty
+  end
+
+  it "dist/boot.js" do
+    contents = File.readlines_stripped("dummy/dist/boot.js")
+
+    contents.wont_be_empty
+    contents.must_have_at_least_one_matching(/Elm\.Main\.init/)
+  end
+
+  it "dist/service-worker.js" do
+    contents = File.readlines_stripped("dummy/dist/service-worker.js")
+
+    contents.wont_be_empty
+    contents.must_have_at_least_one_matching(/v1\.files/)
+  end
+
+  it "dist/main.css" do
+    contents = File.readlines_stripped("dummy/dist/main.css")
+
+    contents.wont_be_empty
+    contents.must_have_at_least_one_matching(/body/)
   end
 end
 

--- a/test.rb
+++ b/test.rb
@@ -46,6 +46,8 @@ describe "Elm.mk test" do
       contents.must_include "elm-stuff"
       contents.must_include "node_modules"
       contents.must_include "elm.js"
+      contents.must_include "build"
+      contents.must_include "bin"
     end
 
     it "Makefile" do

--- a/test.rb
+++ b/test.rb
@@ -111,7 +111,7 @@ describe "Elm.mk test" do
       contents = File.readlines_stripped("dummy/build/boot.js")
 
       contents.wont_be_empty
-      contents.must_have_at_least_one_matching(/Elm\.Main\.embed/)
+      contents.must_have_at_least_one_matching(/Elm\.Main\.init/)
     end
 
     it "build/service-worker.js" do

--- a/test.rb
+++ b/test.rb
@@ -55,11 +55,11 @@ describe "Elm.mk test" do
       contents.must_include "include elm.mk"
     end
 
-    it "elm-package.json" do
-      contents = File.readlines_stripped("dummy/elm-package.json")
+    it "elm.json" do
+      contents = File.readlines_stripped("dummy/elm.json")
 
       contents.wont_be_empty
-      contents.must_have_at_least_one_matching(/elm-lang\/html/)
+      contents.must_have_at_least_one_matching(/elm\/html/)
     end
 
     it "modd.conf" do
@@ -83,14 +83,10 @@ describe "Elm.mk test" do
     end
 
     it "elm source files" do
-      ["Main.elm", "Types.elm", "State.elm", "View.elm"].each do |file|
-        contents = File.readlines_stripped("dummy/src/#{file}")
+      contents = File.readlines_stripped("dummy/src/Main.elm")
 
-        module_name = file.split(".").first
-
-        contents.wont_be_empty
-        contents.first.must_include("module #{module_name}")
-      end
+      contents.wont_be_empty
+      contents.first.must_include("module Main exposing (main)")
     end
   end
 


### PR DESCRIPTION
- [x] Install new compiler from GitHub releases
- [x] Switch to elm.json (suboptimal as the contents are included in elm.mk)
- [x] Switch to single file Main.elm
- [x] Gitignore paths
- [x] Dist targets